### PR TITLE
Refactor resource subsystem to support a transactional API

### DIFF
--- a/apps/newoptical/src/test/java/org/onosproject/newoptical/OpticalPathProvisionerTest.java
+++ b/apps/newoptical/src/test/java/org/onosproject/newoptical/OpticalPathProvisionerTest.java
@@ -76,6 +76,7 @@ import org.onosproject.net.resource.ResourceConsumer;
 import org.onosproject.net.resource.ResourceId;
 import org.onosproject.net.resource.ResourceListener;
 import org.onosproject.net.resource.ResourceService;
+import org.onosproject.net.resource.ResourceTransaction;
 import org.onosproject.net.topology.LinkWeigher;
 import org.onosproject.net.topology.Topology;
 import org.onosproject.net.topology.TopologyServiceAdapter;
@@ -805,6 +806,10 @@ public class OpticalPathProvisionerTest {
     }
 
     private static class TestResourceService implements ResourceService {
+        @Override
+        public ResourceTransaction newTransaction() {
+            return null;
+        }
 
         @Override
         public List<ResourceAllocation> allocate(ResourceConsumer consumer, List<? extends Resource> resources) {
@@ -822,7 +827,6 @@ public class OpticalPathProvisionerTest {
 
         @Override
         public boolean release(ResourceConsumer consumer) {
-
             return true;
         }
 

--- a/apps/pce/app/src/test/java/org/onosproject/pce/pceservice/ResourceServiceAdapter.java
+++ b/apps/pce/app/src/test/java/org/onosproject/pce/pceservice/ResourceServiceAdapter.java
@@ -22,6 +22,7 @@ import org.onosproject.net.resource.ResourceId;
 import org.onosproject.net.resource.ResourceListener;
 import org.onosproject.net.resource.Resource;
 import org.onosproject.net.resource.ResourceService;
+import org.onosproject.net.resource.ResourceTransaction;
 
 import java.util.Collection;
 import java.util.List;
@@ -31,6 +32,12 @@ import java.util.Set;
  * Adapter for resource service for path computation.
  */
 public class ResourceServiceAdapter implements ResourceService {
+
+    @Override
+    public ResourceTransaction newTransaction() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
     @Override
     public void addListener(ResourceListener listener) {

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceCommitStatus.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceCommitStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-present Open Networking Laboratory
+ * Copyright 2017-present Open Networking Laboratory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,23 @@
  */
 package org.onosproject.net.resource;
 
-import com.google.common.annotations.Beta;
-import org.onosproject.store.Store;
-
 /**
- * Service for storing resource and consumer information.
+ * Resource transaction commit status.
  */
-@Beta
-public interface ResourceStore extends Store<ResourceEvent, ResourceStoreDelegate>, ResourceStoreBase {
+public enum ResourceCommitStatus {
+    /**
+     * Indicates that a resource transaction succeeded.
+     */
+    SUCCEEDED,
 
     /**
-     * Creates a new resource transaction context.
-     *
-     * @return a new resource transaction context
+     * Indicates that a resource transaction failed due to an allocation conflict.
      */
-    ResourceTransactionContext newTransaction();
+    FAILED_ALLOCATION,
 
+    /**
+     * Indicates that a resource transaction failed due to a concurrent transaction holding a lock on shared keys.
+     * Transactions failed with this status can be retried.
+     */
+    FAILED_CONCURRENT_TRANSACTION,
 }

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceQueryService.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-present Open Networking Laboratory
+ * Copyright 2017-present Open Networking Laboratory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceService.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceService.java
@@ -15,13 +15,13 @@
  */
 package org.onosproject.net.resource;
 
-import com.google.common.annotations.Beta;
-import com.google.common.collect.ImmutableList;
-import org.onosproject.event.ListenerService;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
+import org.onosproject.event.ListenerService;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -30,6 +30,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Beta
 public interface ResourceService extends ResourceQueryService, ListenerService<ResourceEvent, ResourceListener> {
+
+    /**
+     * Creates a new resource transaction.
+     *
+     * @return a new resource transaction
+     */
+    ResourceTransaction newTransaction();
+
     /**
      * Allocates the specified resource to the specified user.
      *
@@ -75,11 +83,42 @@ public interface ResourceService extends ResourceQueryService, ListenerService<R
      * @return non-empty list of allocation information if succeeded, otherwise empty list
      */
     default List<ResourceAllocation> allocate(ResourceConsumer consumer, Resource... resources) {
-        checkNotNull(consumer);
-        checkNotNull(resources);
-
-        return allocate(consumer, Arrays.asList(resources));
+        return allocate(checkNotNull(consumer), Arrays.asList(checkNotNull(resources)));
     }
+
+    /**
+     * Transactionally allocates or updates the specified resources.
+     * All allocations are made when this method succeeds, or no allocation is made when this method fails.
+     *
+     * @param consumer  resource user which the resources are allocated to
+     * @param resource resource to be allocated
+     * @return non-empty list of allocation information if succeeded, otherwise empty list
+     */
+    default List<ResourceAllocation> update(ResourceConsumer consumer, Resource resource) {
+        return update(consumer, ImmutableList.of(resource));
+    }
+
+    /**
+     * Transactionally allocates or updates the specified resources.
+     * All allocations are made when this method succeeds, or no allocation is made when this method fails.
+     *
+     * @param consumer  resource user which the resources are allocated to
+     * @param resources resources to be allocated
+     * @return non-empty list of allocation information if succeeded, otherwise empty list
+     */
+    default List<ResourceAllocation> update(ResourceConsumer consumer, Resource... resources) {
+        return update(checkNotNull(consumer), Arrays.asList(checkNotNull(resources)));
+    }
+
+    /**
+     * Transactionally allocates or updates the specified resources.
+     * All allocations are made when this method succeeds, or no allocation is made when this method fails.
+     *
+     * @param consumer  resource user which the resources are allocated to
+     * @param resources resources to be allocated
+     * @return non-empty list of allocation information if succeeded, otherwise empty list
+     */
+    List<ResourceAllocation> update(ResourceConsumer consumer, List<? extends Resource> resources);
 
     /**
      * Releases the specified resource allocation.
@@ -88,9 +127,7 @@ public interface ResourceService extends ResourceQueryService, ListenerService<R
      * @return true if succeeded, otherwise false
      */
     default boolean release(ResourceAllocation allocation) {
-        checkNotNull(allocation);
-
-        return release(ImmutableList.of(allocation));
+        return release(ImmutableList.of(checkNotNull(allocation)));
     }
 
     /**
@@ -110,9 +147,7 @@ public interface ResourceService extends ResourceQueryService, ListenerService<R
      * @return true if succeeded, otherwise false
      */
     default boolean release(ResourceAllocation... allocations) {
-        checkNotNull(allocations);
-
-        return release(ImmutableList.copyOf(allocations));
+        return release(ImmutableList.copyOf(checkNotNull(allocations)));
     }
 
     /**
@@ -124,5 +159,4 @@ public interface ResourceService extends ResourceQueryService, ListenerService<R
      */
     boolean release(ResourceConsumer consumer);
 
-    // TODO: listener and event mechanism need to be considered
 }

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceStoreBase.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceStoreBase.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.net.resource;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Base interface for resource storage.
+ */
+@Beta
+public interface ResourceStoreBase {
+
+    /**
+     * Returns the resource consumers to whom the specified resource is allocated.
+     * The return value is a list having only one element when the given resource is discrete type.
+     * The return value may have multiple elements when the given resource is continuous type.
+     *
+     * @param id ID of the resource whose allocated consumer to be returned
+     * @return resource consumers who are allocated the resource.
+     * Returns empty list if there is no such consumer.
+     */
+    List<ResourceAllocation> getResourceAllocations(ResourceId id);
+
+    /**
+     * Returns the availability of the specified resource.
+     *
+     * @param resource resource to check the availability
+     * @return true if available, otherwise false
+     */
+    boolean isAvailable(Resource resource);
+
+    /**
+     * Returns a collection of the resources allocated to the specified consumer.
+     *
+     * @param consumer resource consumer whose allocated resource are searched for
+     * @return a collection of the resources allocated to the specified consumer
+     */
+    Collection<Resource> getResources(ResourceConsumer consumer);
+
+    /**
+     * Returns a set of the child resources of the specified parent.
+     *
+     * @param parent ID of the parent of the resource to be returned
+     * @return a set of the child resources of the specified resource
+     */
+    Set<Resource> getChildResources(DiscreteResourceId parent);
+
+    /**
+     * Returns a set of the child resources of the specified parent and whose type is
+     * the specified class.
+     *
+     * @param parent ID of the parent of the resources to be returned
+     * @param cls class instance of the children
+     * @param <T> type of the resource
+     * @return a set of the child resources of the specified parent and whose type is
+     * the specified class
+     */
+    <T> Set<Resource> getChildResources(DiscreteResourceId parent, Class<T> cls);
+
+    /**
+     * Returns a collection of the resources which are children of the specified parent and
+     * whose type is the specified class.
+     *
+     * @param parent ID of the parent of the resources to be returned
+     * @param cls class instance of the children
+     * @param <T> type of the resource
+     * @return a collection of the resources which belongs to the specified subject and
+     * whose type is the specified class.
+     */
+    <T> Collection<Resource> getAllocatedResources(DiscreteResourceId parent, Class<T> cls);
+
+}

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceTransaction.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceTransaction.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.net.resource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Resource transaction.
+ */
+public interface ResourceTransaction extends ResourceQueryService, AutoCloseable {
+
+    /**
+     * Allocates the specified resource to the specified user.
+     *
+     * @param consumer resource user which the resource is allocated to
+     * @param resource resource to be allocated
+     */
+    default void allocate(ResourceConsumer consumer, Resource resource) {
+        allocate(consumer, ImmutableList.of(checkNotNull(resource)));
+    }
+
+    /**
+     * Transactionally allocates the specified resources to the specified user.
+     * All allocations are made when this method succeeds, or no allocation is made when this method fails.
+     *
+     * @param consumer  resource user which the resources are allocated to
+     * @param resources resources to be allocated
+     */
+    void allocate(ResourceConsumer consumer, List<? extends Resource> resources);
+
+    /**
+     * Transactionally allocates the specified resources to the specified user.
+     * All allocations are made when this method succeeds, or no allocation is made when this method fails.
+     *
+     * @param consumer  resource user which the resources are allocated to
+     * @param resources resources to be allocated
+     */
+    default void allocate(ResourceConsumer consumer, Resource... resources) {
+        allocate(checkNotNull(consumer), Arrays.asList(checkNotNull(resources)));
+    }
+
+    /**
+     * Releases the specified resource allocation.
+     *
+     * @param allocation resource allocation to be released
+     */
+    default void release(ResourceAllocation allocation) {
+        release(ImmutableList.of(checkNotNull(allocation)));
+    }
+
+    /**
+     * Transactionally releases the specified resource allocations.
+     * All allocations are released when this method succeeded, or no allocation is released when this method fails.
+     *
+     * @param allocations resource allocations to be released
+     */
+    void release(List<ResourceAllocation> allocations);
+
+    /**
+     * Transactionally releases the specified resource allocations.
+     * All allocations are released when this method succeeded, or no allocation is released when this method fails.
+     *
+     * @param allocations resource allocations to be released
+     */
+    default void release(ResourceAllocation... allocations) {
+        release(ImmutableList.copyOf(checkNotNull(allocations)));
+    }
+
+    /**
+     * Transactionally releases the resources allocated to the specified consumer.
+     * All allocations are released when this method succeeded, or no allocation is released when this method fails.
+     *
+     * @param consumer consumer whose allocated resources are to be released
+     */
+    void release(ResourceConsumer consumer);
+
+    /**
+     * Commits the transaction.
+     *
+     * @return indicates whether the transaction was successfully committed
+     */
+    ResourceCommitStatus commit();
+
+    /**
+     * Aborts the transaction.
+     */
+    void abort();
+
+    /**
+     * Closes the transaction.
+     * <p>
+     * If the transaction has not been committed, it will be aborted.
+     */
+    @Override
+    void close();
+
+}

--- a/core/api/src/main/java/org/onosproject/net/resource/ResourceTransactionContext.java
+++ b/core/api/src/main/java/org/onosproject/net/resource/ResourceTransactionContext.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.net.resource;
+
+import java.util.List;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Resource transaction context.
+ */
+@Beta
+public interface ResourceTransactionContext extends ResourceStoreBase, AutoCloseable {
+
+    /**
+     * Registers the resources in transactional way.
+     * Resource registration must be done before resource allocation. The state after completion
+     * of this method is all the resources are registered, or none of the given resources is registered.
+     * The whole registration fails when any one of the resource can't be registered.
+     *
+     * @param resources resources to be registered
+     */
+    void register(List<? extends Resource> resources);
+
+    /**
+     * Unregisters the resources in transactional way.
+     * The state after completion of this method is all the resources are unregistered,
+     * or none of the given resources is unregistered. The whole unregistration fails when any one of the
+     * resource can't be unregistered.
+     *
+     * @param ids resources to be unregistered
+     */
+    void unregister(List<? extends ResourceId> ids);
+
+    /**
+     * Allocates the specified resources to the specified consumer in transactional way.
+     * The state after completion of this method is all the resources are allocated to the consumer,
+     * or no resource is allocated to the consumer. The whole allocation fails when any one of
+     * the resource can't be allocated.
+     *
+     * @param resources resources to be allocated
+     * @param consumer resource consumer which the resources are allocated to
+     */
+    void allocate(List<? extends Resource> resources, ResourceConsumer consumer);
+
+    /**
+     * Releases the specified allocated resources in transactional way.
+     * The state after completion of this method is all the resources
+     * are released from the consumer, or no resource is released. The whole release fails
+     * when any one of the resource can't be released. The size of the list of resources and
+     * that of consumers must be equal. The resource and consumer with the same position from
+     * the head of each list correspond to each other.
+     *
+     * @param allocations allocaitons to be released
+     */
+    void release(List<ResourceAllocation> allocations);
+
+    /**
+     * Commits the transaction.
+     *
+     * @return indicates whether the transaction was successfully committed
+     */
+    ResourceCommitStatus commit();
+
+    /**
+     * Aborts the transaction.
+     */
+    void abort();
+
+    /**
+     * Closes the transaction.
+     */
+    @Override
+    void close();
+
+}

--- a/core/api/src/test/java/org/onosproject/net/resource/MockResourceService.java
+++ b/core/api/src/test/java/org/onosproject/net/resource/MockResourceService.java
@@ -15,15 +15,6 @@
  */
 package org.onosproject.net.resource;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-
-import org.onlab.packet.MplsLabel;
-import org.onlab.packet.VlanId;
-import org.onlab.util.Bandwidth;
-import org.onlab.util.Tools;
-import org.onosproject.net.TributarySlot;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +24,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.onlab.packet.MplsLabel;
+import org.onlab.packet.VlanId;
+import org.onlab.util.Bandwidth;
+import org.onlab.util.Tools;
+import org.onosproject.net.TributarySlot;
 
 public class MockResourceService implements ResourceService {
 
@@ -53,6 +52,12 @@ public class MockResourceService implements ResourceService {
     }
 
     @Override
+    public ResourceTransaction newTransaction() {
+        // TODO: Test resource transactions
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<ResourceAllocation> allocate(ResourceConsumer consumer, List<? extends Resource> resources) {
         assignment.putAll(
                 resources.stream().collect(Collectors.toMap(Function.identity(), x -> consumer))
@@ -61,6 +66,12 @@ public class MockResourceService implements ResourceService {
         return resources.stream()
                 .map(x -> new ResourceAllocation(x, consumer))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ResourceAllocation> update(ResourceConsumer consumer, List<? extends Resource> resources) {
+        // TODO: Test update method
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/core/net/src/main/java/org/onosproject/net/resource/impl/ResourceManagerTransaction.java
+++ b/core/net/src/main/java/org/onosproject/net/resource/impl/ResourceManagerTransaction.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.net.resource.impl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import org.onlab.util.GuavaCollectors;
+import org.onlab.util.Tools;
+import org.onosproject.net.resource.DiscreteResourceId;
+import org.onosproject.net.resource.Resource;
+import org.onosproject.net.resource.ResourceAllocation;
+import org.onosproject.net.resource.ResourceCommitStatus;
+import org.onosproject.net.resource.ResourceConsumer;
+import org.onosproject.net.resource.ResourceId;
+import org.onosproject.net.resource.ResourceTransaction;
+import org.onosproject.net.resource.ResourceTransactionContext;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.onosproject.security.AppGuard.checkPermission;
+import static org.onosproject.security.AppPermission.Type.RESOURCE_READ;
+import static org.onosproject.security.AppPermission.Type.RESOURCE_WRITE;
+
+/**
+ * Resource transaction implementation.
+ */
+public class ResourceManagerTransaction implements ResourceTransaction {
+    private final ResourceTransactionContext context;
+
+    public ResourceManagerTransaction(ResourceTransactionContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public ResourceCommitStatus commit() {
+        return context.commit();
+    }
+
+    @Override
+    public void abort() {
+        context.abort();
+    }
+
+    @Override
+    public List<ResourceAllocation> getResourceAllocations(ResourceId id) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(id);
+
+        return context.getResourceAllocations(id);
+    }
+
+    @Override
+    public <T> Collection<ResourceAllocation> getResourceAllocations(DiscreteResourceId parent, Class<T> cls) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(parent);
+        checkNotNull(cls);
+
+        // We access store twice in this method, then the store may be updated by others
+        Collection<Resource> resources = context.getAllocatedResources(parent, cls);
+        return resources.stream()
+                .flatMap(resource -> context.getResourceAllocations(resource.id()).stream())
+                .collect(GuavaCollectors.toImmutableList());
+    }
+
+    @Override
+    public Collection<ResourceAllocation> getResourceAllocations(ResourceConsumer consumer) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(consumer);
+
+        Collection<Resource> resources = context.getResources(consumer);
+        return resources.stream()
+                .map(x -> new ResourceAllocation(x, consumer))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Resource> getAvailableResources(DiscreteResourceId parent) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(parent);
+
+        Set<Resource> children = context.getChildResources(parent);
+        return children.stream()
+                // We access store twice in this method, then the store may be updated by others
+                .filter(context::isAvailable)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public <T> Set<Resource> getAvailableResources(DiscreteResourceId parent, Class<T> cls) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(parent);
+        checkNotNull(cls);
+
+        return context.getChildResources(parent, cls).stream()
+                // We access store twice in this method, then the store may be updated by others
+                .filter(context::isAvailable)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public <T> Set<T> getAvailableResourceValues(DiscreteResourceId parent, Class<T> cls) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(parent);
+        checkNotNull(cls);
+
+        return context.getChildResources(parent, cls).stream()
+                // We access store twice in this method, then the store may be updated by others
+                .filter(context::isAvailable)
+                .map(x -> x.valueAs(cls))
+                .flatMap(Tools::stream)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Resource> getRegisteredResources(DiscreteResourceId parent) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(parent);
+        return context.getChildResources(parent);
+    }
+
+    @Override
+    public boolean isAvailable(Resource resource) {
+        checkPermission(RESOURCE_READ);
+        checkNotNull(resource);
+        return context.isAvailable(resource);
+    }
+
+    @Override
+    public void allocate(ResourceConsumer consumer, List<? extends Resource> resources) {
+        checkPermission(RESOURCE_WRITE);
+        checkNotNull(consumer);
+        checkNotNull(resources);
+        context.allocate(resources, consumer);
+    }
+
+    @Override
+    public void release(List<ResourceAllocation> allocations) {
+        checkPermission(RESOURCE_WRITE);
+        checkNotNull(allocations);
+        context.release(allocations);
+    }
+
+    @Override
+    public void release(ResourceConsumer consumer) {
+        checkNotNull(consumer);
+        Collection<ResourceAllocation> allocations = getResourceAllocations(consumer);
+        release(ImmutableList.copyOf(allocations));
+    }
+
+    @Override
+    public void close() {
+        context.close();
+    }
+}

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentContinuousResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentContinuousResourceSubStore.java
@@ -15,6 +15,12 @@
  */
 package org.onosproject.store.resource.impl;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.onosproject.net.resource.ContinuousResource;
@@ -25,14 +31,7 @@ import org.onosproject.net.resource.ResourceAllocation;
 import org.onosproject.net.resource.ResourceConsumerId;
 import org.onosproject.store.service.ConsistentMap;
 import org.onosproject.store.service.StorageService;
-import org.onosproject.store.service.TransactionContext;
 import org.onosproject.store.service.Versioned;
-
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.onosproject.store.resource.impl.ConsistentResourceStore.SERIALIZER;
 
@@ -40,8 +39,7 @@ import static org.onosproject.store.resource.impl.ConsistentResourceStore.SERIAL
 /**
  * Consistent substore for continuous resources.
  */
-class ConsistentContinuousResourceSubStore implements ConsistentResourceSubStore
-        <ContinuousResourceId, ContinuousResource, TransactionalContinuousResourceSubStore> {
+class ConsistentContinuousResourceSubStore implements ContinuousResourceSubStore {
     private ConsistentMap<ContinuousResourceId, ContinuousResourceAllocation> consumers;
     private ConsistentMap<DiscreteResourceId, Set<ContinuousResource>> childMap;
 
@@ -56,11 +54,6 @@ class ConsistentContinuousResourceSubStore implements ConsistentResourceSubStore
                 .build();
 
         childMap.put(Resource.ROOT.id(), new LinkedHashSet<>());
-    }
-
-    @Override
-    public TransactionalContinuousResourceSubStore transactional(TransactionContext tx) {
-        return new TransactionalContinuousResourceSubStore(tx);
     }
 
     // computational complexity: O(n) where n is the number of the existing allocations for the resource
@@ -138,10 +131,7 @@ class ConsistentContinuousResourceSubStore implements ConsistentResourceSubStore
                 // .filter(x -> !continuousConsumers.get(x.id()).value().allocations().isEmpty());
                 .filter(resource -> {
                     Versioned<ContinuousResourceAllocation> allocation = consumers.get(resource.id());
-                    if (allocation == null) {
-                        return false;
-                    }
-                    return !allocation.value().allocations().isEmpty();
+                    return allocation != null && !allocation.value().allocations().isEmpty();
                 });
     }
 

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentDiscreteResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentDiscreteResourceSubStore.java
@@ -15,6 +15,11 @@
  */
 package org.onosproject.store.resource.impl;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.onosproject.net.resource.DiscreteResource;
@@ -25,21 +30,14 @@ import org.onosproject.net.resource.ResourceConsumerId;
 import org.onosproject.net.resource.Resources;
 import org.onosproject.store.service.ConsistentMap;
 import org.onosproject.store.service.StorageService;
-import org.onosproject.store.service.TransactionContext;
 import org.onosproject.store.service.Versioned;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.onosproject.store.resource.impl.ConsistentResourceStore.SERIALIZER;
 
 /**
  * Consistent substore for discrete resources.
  */
-class ConsistentDiscreteResourceSubStore implements ConsistentResourceSubStore
-        <DiscreteResourceId, DiscreteResource, TransactionalDiscreteResourceSubStore> {
+class ConsistentDiscreteResourceSubStore implements DiscreteResourceSubStore {
     private ConsistentMap<DiscreteResourceId, ResourceConsumerId> consumers;
     private ConsistentMap<DiscreteResourceId, DiscreteResources> childMap;
 
@@ -54,11 +52,6 @@ class ConsistentDiscreteResourceSubStore implements ConsistentResourceSubStore
                 .build();
 
         childMap.put(Resource.ROOT.id(), DiscreteResources.empty());
-    }
-
-    @Override
-    public TransactionalDiscreteResourceSubStore transactional(TransactionContext tx) {
-        return new TransactionalDiscreteResourceSubStore(tx);
     }
 
     // computational complexity: O(1)

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceStore.java
@@ -16,55 +16,31 @@
 package org.onosproject.store.resource.impl;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.ImmutableSet;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.Service;
 import org.onlab.util.KryoNamespace;
-import org.onlab.util.Tools;
-import org.onosproject.net.resource.ContinuousResource;
-import org.onosproject.net.resource.ContinuousResourceId;
-import org.onosproject.net.resource.DiscreteResource;
 import org.onosproject.net.resource.DiscreteResourceId;
 import org.onosproject.net.resource.Resource;
 import org.onosproject.net.resource.ResourceAllocation;
 import org.onosproject.net.resource.ResourceConsumer;
-import org.onosproject.net.resource.ResourceConsumerId;
 import org.onosproject.net.resource.ResourceEvent;
 import org.onosproject.net.resource.ResourceId;
 import org.onosproject.net.resource.ResourceStore;
 import org.onosproject.net.resource.ResourceStoreDelegate;
-import org.onosproject.net.resource.Resources;
+import org.onosproject.net.resource.ResourceTransactionContext;
 import org.onosproject.store.AbstractStore;
 import org.onosproject.store.serializers.KryoNamespaces;
-import org.onosproject.store.service.CommitStatus;
-import org.onosproject.store.service.DistributedPrimitive;
 import org.onosproject.store.service.Serializer;
 import org.onosproject.store.service.StorageService;
-import org.onosproject.store.service.TransactionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.onosproject.net.resource.ResourceEvent.Type.RESOURCE_ADDED;
-import static org.onosproject.net.resource.ResourceEvent.Type.RESOURCE_REMOVED;
 
 /**
  * Implementation of ResourceStore using TransactionalMap.
@@ -90,350 +66,50 @@ public class ConsistentResourceStore extends AbstractStore<ResourceEvent, Resour
             .build());
 
     @Reference(cardinality = ReferenceCardinality.MANDATORY_UNARY)
-    protected StorageService service;
+    protected StorageService storageService;
 
-    private ConsistentDiscreteResourceSubStore discreteStore;
-    private ConsistentContinuousResourceSubStore continuousStore;
+    private ConsistentResourceStoreBase base;
 
     @Activate
     public void activate() {
-        discreteStore = new ConsistentDiscreteResourceSubStore(service);
-        continuousStore = new ConsistentContinuousResourceSubStore(service);
-
+        ConsistentDiscreteResourceSubStore discreteStore = new ConsistentDiscreteResourceSubStore(storageService);
+        ConsistentContinuousResourceSubStore continuousStore = new ConsistentContinuousResourceSubStore(storageService);
+        base = new ConsistentResourceStoreBase(discreteStore, continuousStore);
         log.info("Started");
     }
 
-    // Computational complexity: O(1) if the resource is discrete type.
-    // O(n) if the resource is continuous type where n is the number of the existing allocations for the resource
+    @Override
+    public ResourceTransactionContext newTransaction() {
+        return new ConsistentResourceTransactionContext(storageService.transactionContextBuilder().build());
+    }
+
     @Override
     public List<ResourceAllocation> getResourceAllocations(ResourceId id) {
-        checkNotNull(id);
-        checkArgument(id instanceof DiscreteResourceId || id instanceof ContinuousResourceId);
-
-        if (id instanceof DiscreteResourceId) {
-            return discreteStore.getResourceAllocations((DiscreteResourceId) id);
-        } else {
-            return continuousStore.getResourceAllocations((ContinuousResourceId) id);
-        }
+        return base.getResourceAllocations(id);
     }
 
-    @Override
-    public boolean register(List<? extends Resource> resources) {
-        checkNotNull(resources);
-        if (log.isTraceEnabled()) {
-            resources.forEach(r -> log.trace("registering {}", r));
-        }
-
-        // Retry the transaction until successful.
-        while (true) {
-            TransactionContext tx = service.transactionContextBuilder().build();
-            tx.begin();
-
-            // the order is preserved by LinkedHashMap
-            Map<DiscreteResource, List<Resource>> resourceMap = resources.stream()
-                    .filter(x -> x.parent().isPresent())
-                    .collect(Collectors.groupingBy(x -> x.parent().get(), LinkedHashMap::new, Collectors.toList()));
-
-            TransactionalDiscreteResourceSubStore discreteTxStore = discreteStore.transactional(tx);
-            TransactionalContinuousResourceSubStore continuousTxStore = continuousStore.transactional(tx);
-            for (Map.Entry<DiscreteResource, List<Resource>> entry : resourceMap.entrySet()) {
-                DiscreteResourceId parentId = entry.getKey().id();
-                if (!discreteTxStore.lookup(parentId).isPresent()) {
-                    return abortTransaction(tx);
-                }
-
-                if (!register(discreteTxStore, continuousTxStore, parentId, entry.getValue())) {
-                    return abortTransaction(tx);
-                }
-            }
-
-            try {
-                CommitStatus status = commitTransaction(tx);
-                if (status == CommitStatus.SUCCESS) {
-                    log.trace("Transaction commit succeeded on registration: resources={}", resources);
-                    List<ResourceEvent> events = resources.stream()
-                            .filter(x -> x.parent().isPresent())
-                            .map(x -> new ResourceEvent(RESOURCE_ADDED, x))
-                            .collect(Collectors.toList());
-                    notifyDelegate(events);
-                    return true;
-                }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.warn("Transaction commit failed on registration", e);
-                return false;
-            }
-        }
-    }
-
-    @Override
-    public boolean unregister(List<? extends ResourceId> ids) {
-        checkNotNull(ids);
-
-        // Retry the transaction until successful.
-        while (true) {
-            TransactionContext tx = service.transactionContextBuilder().build();
-            tx.begin();
-
-            TransactionalDiscreteResourceSubStore discreteTxStore = discreteStore.transactional(tx);
-            TransactionalContinuousResourceSubStore continuousTxStore = continuousStore.transactional(tx);
-            // Look up resources by resource IDs
-            List<Resource> resources = ids.stream()
-                    .filter(x -> x.parent().isPresent())
-                    .map(x -> {
-                        // avoid access to consistent map in the case of discrete resource
-                        if (x instanceof DiscreteResourceId) {
-                            return Optional.of(Resources.discrete((DiscreteResourceId) x).resource());
-                        } else {
-                            return continuousTxStore.lookup((ContinuousResourceId) x);
-                        }
-                    })
-                    .flatMap(Tools::stream)
-                    .collect(Collectors.toList());
-            // the order is preserved by LinkedHashMap
-            Map<DiscreteResourceId, List<Resource>> resourceMap = resources.stream().collect(
-                    Collectors.groupingBy(x -> x.parent().get().id(), LinkedHashMap::new, Collectors.toList()));
-
-            for (Map.Entry<DiscreteResourceId, List<Resource>> entry : resourceMap.entrySet()) {
-                if (!unregister(discreteTxStore, continuousTxStore, entry.getKey(), entry.getValue())) {
-                    log.warn("Failed to unregister {}: Failed to remove {} values.",
-                            entry.getKey(), entry.getValue().size());
-                    return abortTransaction(tx);
-                }
-            }
-
-            try {
-                CommitStatus status = commitTransaction(tx);
-                if (status == CommitStatus.SUCCESS) {
-                    List<ResourceEvent> events = resources.stream()
-                            .filter(x -> x.parent().isPresent())
-                            .map(x -> new ResourceEvent(RESOURCE_REMOVED, x))
-                            .collect(Collectors.toList());
-                    notifyDelegate(events);
-                    return true;
-                }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                String message = resources.stream()
-                        .map(Resource::simpleTypeName)
-                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
-                        .entrySet().stream()
-                        .map(entry -> String.format("%d %s type resources", entry.getValue(), entry.getKey()))
-                        .collect(Collectors.joining(", "));
-                log.warn("Failed to unregister {}: {}", message, e);
-                return false;
-            }
-        }
-    }
-
-    @Override
-    public boolean allocate(List<? extends Resource> resources, ResourceConsumer consumer) {
-        checkNotNull(resources);
-        checkNotNull(consumer);
-
-        while (true) {
-            TransactionContext tx = service.transactionContextBuilder().build();
-            tx.begin();
-
-            TransactionalDiscreteResourceSubStore discreteTxStore = discreteStore.transactional(tx);
-            TransactionalContinuousResourceSubStore continuousTxStore = continuousStore.transactional(tx);
-            for (Resource resource : resources) {
-                if (resource instanceof DiscreteResource) {
-                    if (!discreteTxStore.allocate(consumer.consumerId(), (DiscreteResource) resource)) {
-                        return abortTransaction(tx);
-                    }
-                } else if (resource instanceof ContinuousResource) {
-                    if (!continuousTxStore.allocate(consumer.consumerId(), (ContinuousResource) resource)) {
-                        return abortTransaction(tx);
-                    }
-                }
-            }
-
-            try {
-                if (commitTransaction(tx) == CommitStatus.SUCCESS) {
-                    return true;
-                }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.warn("Failed to allocate {}: {}", resources, e);
-                return false;
-            }
-        }
-    }
-
-    @Override
-    public boolean release(List<ResourceAllocation> allocations) {
-        checkNotNull(allocations);
-
-        while (true) {
-            TransactionContext tx = service.transactionContextBuilder().build();
-            tx.begin();
-
-            TransactionalDiscreteResourceSubStore discreteTxStore = discreteStore.transactional(tx);
-            TransactionalContinuousResourceSubStore continuousTxStore = continuousStore.transactional(tx);
-            for (ResourceAllocation allocation : allocations) {
-                Resource resource = allocation.resource();
-                ResourceConsumerId consumerId = allocation.consumerId();
-
-                if (resource instanceof DiscreteResource) {
-                    if (!discreteTxStore.release(consumerId, (DiscreteResource) resource)) {
-                        return abortTransaction(tx);
-                    }
-                } else if (resource instanceof ContinuousResource) {
-                    if (!continuousTxStore.release(consumerId, (ContinuousResource) resource)) {
-                        return abortTransaction(tx);
-                    }
-                }
-            }
-
-            try {
-                if (commitTransaction(tx) == CommitStatus.SUCCESS) {
-                    return true;
-                }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.warn("Failed to release {}: {}", allocations, e);
-                return false;
-            }
-        }
-    }
-
-    // computational complexity: O(1) if the resource is discrete type.
-    // O(n) if the resource is continuous type where n is the number of the children of
-    // the specified resource's parent
     @Override
     public boolean isAvailable(Resource resource) {
-        checkNotNull(resource);
-        checkArgument(resource instanceof DiscreteResource || resource instanceof ContinuousResource);
-
-        if (resource instanceof DiscreteResource) {
-            // check if already consumed
-            return discreteStore.isAvailable((DiscreteResource) resource);
-        } else {
-            return continuousStore.isAvailable((ContinuousResource) resource);
-        }
+        return base.isAvailable(resource);
     }
 
-    // computational complexity: O(n + m) where n is the number of entries in discreteConsumers
-    // and m is the number of allocations for all continuous resources
     @Override
     public Collection<Resource> getResources(ResourceConsumer consumer) {
-        checkNotNull(consumer);
-
-        // NOTE: getting all entries may become performance bottleneck
-        // TODO: revisit for better backend data structure
-        Stream<DiscreteResource> discrete = discreteStore.getResources(consumer.consumerId());
-        Stream<ContinuousResource> continuous = continuousStore.getResources(consumer.consumerId());
-
-        return Stream.concat(discrete, continuous).collect(Collectors.toList());
+        return base.getResources(consumer);
     }
 
-    // computational complexity: O(1)
     @Override
     public Set<Resource> getChildResources(DiscreteResourceId parent) {
-        checkNotNull(parent);
-
-        return ImmutableSet.<Resource>builder()
-                .addAll(discreteStore.getChildResources(parent))
-                .addAll(continuousStore.getChildResources(parent))
-                .build();
+        return base.getChildResources(parent);
     }
 
     @Override
     public <T> Set<Resource> getChildResources(DiscreteResourceId parent, Class<T> cls) {
-        checkNotNull(parent);
-        checkNotNull(cls);
-
-        return ImmutableSet.<Resource>builder()
-                .addAll(discreteStore.getChildResources(parent, cls))
-                .addAll(continuousStore.getChildResources(parent, cls))
-                .build();
+        return base.getChildResources(parent, cls);
     }
 
-    // computational complexity: O(n) where n is the number of the children of the parent
     @Override
     public <T> Collection<Resource> getAllocatedResources(DiscreteResourceId parent, Class<T> cls) {
-        checkNotNull(parent);
-        checkNotNull(cls);
-
-        Stream<DiscreteResource> discrete = discreteStore.getAllocatedResources(parent, cls);
-        Stream<ContinuousResource> continuous = continuousStore.getAllocatedResources(parent, cls);
-
-        return Stream.concat(discrete, continuous).collect(Collectors.toList());
-    }
-
-    /**
-     * Commits a transaction.
-     *
-     * @param tx the transaction to commit
-     * @return the transaction status
-     */
-    private CommitStatus commitTransaction(TransactionContext tx)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return tx.commit().get(DistributedPrimitive.DEFAULT_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Abort the transaction.
-     *
-     * @param tx transaction context
-     * @return always false
-     */
-    private boolean abortTransaction(TransactionContext tx) {
-        tx.abort();
-        return false;
-    }
-
-    /**
-     * Appends the values to the existing values associated with the specified key.
-     * If the map already has all the given values, appending will not happen.
-     *
-     * @param parent    resource ID of the parent under which the given resources are registered
-     * @param resources resources to be registered
-     * @return true if the operation succeeds, false otherwise.
-     */
-    // computational complexity: O(n) where n is the number of the specified value
-    private boolean register(TransactionalDiscreteResourceSubStore discreteTxStore,
-                             TransactionalContinuousResourceSubStore continuousTxStore,
-                             DiscreteResourceId parent, List<Resource> resources) {
-        // it's assumed that the passed "values" is non-empty
-
-        // This is 2-pass scan. Nicer to have 1-pass scan
-        Set<DiscreteResource> discreteResources = resources.stream()
-                .filter(x -> x instanceof DiscreteResource)
-                .map(x -> (DiscreteResource) x)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        Set<ContinuousResource> continuousResources = resources.stream()
-                .filter(x -> x instanceof ContinuousResource)
-                .map(x -> (ContinuousResource) x)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        return discreteTxStore.register(parent, discreteResources)
-                && continuousTxStore.register(parent, continuousResources);
-    }
-
-    /**
-     * Removes the values from the existing values associated with the specified key.
-     * If the map doesn't contain the given values, removal will not happen.
-     *
-     * @param discreteTxStore   map holding multiple discrete resources for a key
-     * @param continuousTxStore map holding multiple continuous resources for a key
-     * @param parent            resource ID of the parent under which the given resources are unregistered
-     * @param resources         resources to be unregistered
-     * @return true if the operation succeeds, false otherwise
-     */
-    private boolean unregister(TransactionalDiscreteResourceSubStore discreteTxStore,
-                               TransactionalContinuousResourceSubStore continuousTxStore,
-                               DiscreteResourceId parent, List<Resource> resources) {
-        // it's assumed that the passed "values" is non-empty
-
-        // This is 2-pass scan. Nicer to have 1-pass scan
-        Set<DiscreteResource> discreteResources = resources.stream()
-                .filter(x -> x instanceof DiscreteResource)
-                .map(x -> (DiscreteResource) x)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        Set<ContinuousResource> continuousResources = resources.stream()
-                .filter(x -> x instanceof ContinuousResource)
-                .map(x -> (ContinuousResource) x)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        return discreteTxStore.unregister(parent, discreteResources)
-                && continuousTxStore.unregister(parent, continuousResources);
+        return base.getAllocatedResources(parent, cls);
     }
 }

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceStoreBase.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceStoreBase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.store.resource.impl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableSet;
+import org.onosproject.net.resource.ContinuousResource;
+import org.onosproject.net.resource.ContinuousResourceId;
+import org.onosproject.net.resource.DiscreteResource;
+import org.onosproject.net.resource.DiscreteResourceId;
+import org.onosproject.net.resource.Resource;
+import org.onosproject.net.resource.ResourceAllocation;
+import org.onosproject.net.resource.ResourceConsumer;
+import org.onosproject.net.resource.ResourceId;
+import org.onosproject.net.resource.ResourceStoreBase;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Consistent resource store base.
+ */
+public class ConsistentResourceStoreBase implements ResourceStoreBase {
+    private final DiscreteResourceSubStore discreteStore;
+    private final ContinuousResourceSubStore continuousStore;
+
+    public ConsistentResourceStoreBase(
+            DiscreteResourceSubStore discreteStore,
+            ContinuousResourceSubStore continuousStore) {
+        this.discreteStore = discreteStore;
+        this.continuousStore = continuousStore;
+    }
+
+    // Computational complexity: O(1) if the resource is discrete type.
+    // O(n) if the resource is continuous type where n is the number of the existing allocations for the resource
+    @Override
+    public List<ResourceAllocation> getResourceAllocations(ResourceId id) {
+        checkNotNull(id);
+        checkArgument(id instanceof DiscreteResourceId || id instanceof ContinuousResourceId);
+
+        if (id instanceof DiscreteResourceId) {
+            return discreteStore.getResourceAllocations((DiscreteResourceId) id);
+        } else {
+            return continuousStore.getResourceAllocations((ContinuousResourceId) id);
+        }
+    }
+
+    // computational complexity: O(1) if the resource is discrete type.
+    // O(n) if the resource is continuous type where n is the number of the children of
+    // the specified resource's parent
+    @Override
+    public boolean isAvailable(Resource resource) {
+        checkNotNull(resource);
+        checkArgument(resource instanceof DiscreteResource || resource instanceof ContinuousResource);
+
+        if (resource instanceof DiscreteResource) {
+            // check if already consumed
+            return discreteStore.isAvailable((DiscreteResource) resource);
+        } else {
+            return continuousStore.isAvailable((ContinuousResource) resource);
+        }
+    }
+
+    // computational complexity: O(n + m) where n is the number of entries in discreteConsumers
+    // and m is the number of allocations for all continuous resources
+    @Override
+    public Collection<Resource> getResources(ResourceConsumer consumer) {
+        checkNotNull(consumer);
+
+        // NOTE: getting all entries may become performance bottleneck
+        // TODO: revisit for better backend data structure
+        Stream<DiscreteResource> discrete = discreteStore.getResources(consumer.consumerId());
+        Stream<ContinuousResource> continuous = continuousStore.getResources(consumer.consumerId());
+
+        return Stream.concat(discrete, continuous).collect(Collectors.toList());
+    }
+
+    // computational complexity: O(1)
+    @Override
+    public Set<Resource> getChildResources(DiscreteResourceId parent) {
+        checkNotNull(parent);
+
+        return ImmutableSet.<Resource>builder()
+                .addAll(discreteStore.getChildResources(parent))
+                .addAll(continuousStore.getChildResources(parent))
+                .build();
+    }
+
+    @Override
+    public <T> Set<Resource> getChildResources(DiscreteResourceId parent, Class<T> cls) {
+        checkNotNull(parent);
+        checkNotNull(cls);
+
+        return ImmutableSet.<Resource>builder()
+                .addAll(discreteStore.getChildResources(parent, cls))
+                .addAll(continuousStore.getChildResources(parent, cls))
+                .build();
+    }
+
+    // computational complexity: O(n) where n is the number of the children of the parent
+    @Override
+    public <T> Collection<Resource> getAllocatedResources(DiscreteResourceId parent, Class<T> cls) {
+        checkNotNull(parent);
+        checkNotNull(cls);
+
+        Stream<DiscreteResource> discrete = discreteStore.getAllocatedResources(parent, cls);
+        Stream<ContinuousResource> continuous = continuousStore.getAllocatedResources(parent, cls);
+
+        return Stream.concat(discrete, continuous).collect(Collectors.toList());
+    }
+
+}

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceSubStore.java
@@ -15,30 +15,20 @@
  */
 package org.onosproject.store.resource.impl;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.onosproject.net.resource.DiscreteResourceId;
 import org.onosproject.net.resource.Resource;
 import org.onosproject.net.resource.ResourceAllocation;
 import org.onosproject.net.resource.ResourceConsumerId;
 import org.onosproject.net.resource.ResourceId;
-import org.onosproject.store.service.TransactionContext;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Interface for consistent resource substores.
  */
-interface ConsistentResourceSubStore
-        <T extends ResourceId, U extends Resource, V extends TransactionalResourceSubStore> {
-
-    /**
-     * Returns a new transactional substore.
-     *
-     * @param tx the transaction context
-     * @return a transactional resource substore
-     */
-    V transactional(TransactionContext tx);
+interface ConsistentResourceSubStore<T extends ResourceId, U extends Resource> {
 
     /**
      * Returns a list of resource allocations for the given resource ID.

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceTransactionContext.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ConsistentResourceTransactionContext.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2017-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.store.resource.impl;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.onlab.util.Tools;
+import org.onosproject.net.resource.ContinuousResource;
+import org.onosproject.net.resource.ContinuousResourceId;
+import org.onosproject.net.resource.DiscreteResource;
+import org.onosproject.net.resource.DiscreteResourceId;
+import org.onosproject.net.resource.Resource;
+import org.onosproject.net.resource.ResourceAllocation;
+import org.onosproject.net.resource.ResourceCommitStatus;
+import org.onosproject.net.resource.ResourceConsumer;
+import org.onosproject.net.resource.ResourceConsumerId;
+import org.onosproject.net.resource.ResourceId;
+import org.onosproject.net.resource.ResourceTransactionContext;
+import org.onosproject.net.resource.Resources;
+import org.onosproject.store.service.CommitStatus;
+import org.onosproject.store.service.TransactionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Consistent resource transaction context.
+ */
+public class ConsistentResourceTransactionContext
+        extends ConsistentResourceStoreBase
+        implements ResourceTransactionContext {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final TransactionalDiscreteResourceSubStore discreteSubstore;
+    private final TransactionalContinuousResourceSubStore continuousSubstore;
+    private final TransactionContext transactionContext;
+    private ResourceCommitStatus commitStatus;
+
+    ConsistentResourceTransactionContext(TransactionContext transactionContext) {
+        this(new TransactionalDiscreteResourceSubStore(transactionContext),
+                new TransactionalContinuousResourceSubStore(transactionContext),
+                transactionContext);
+    }
+
+    private ConsistentResourceTransactionContext(
+            TransactionalDiscreteResourceSubStore discreteSubstore,
+            TransactionalContinuousResourceSubStore continuousSubstore,
+            TransactionContext transactionContext) {
+        super(discreteSubstore, continuousSubstore);
+        this.discreteSubstore = discreteSubstore;
+        this.continuousSubstore = continuousSubstore;
+        this.transactionContext = transactionContext;
+        transactionContext.begin();
+    }
+
+    @Override
+    public void register(List<? extends Resource> resources) {
+        // If the transaction was already aborted, skip this operation.
+        if (!transactionContext.isOpen()) {
+            return;
+        }
+
+        checkNotNull(resources);
+        if (log.isTraceEnabled()) {
+            resources.forEach(r -> log.trace("registering {}", r));
+        }
+
+        // the order is preserved by LinkedHashMap
+        Map<DiscreteResource, List<Resource>> resourceMap = resources.stream()
+                .filter(x -> x.parent().isPresent())
+                .collect(Collectors.groupingBy(x -> x.parent().get(), LinkedHashMap::new, Collectors.toList()));
+
+        for (Map.Entry<DiscreteResource, List<Resource>> entry : resourceMap.entrySet()) {
+            DiscreteResourceId parentId = entry.getKey().id();
+            if (!discreteSubstore.lookup(parentId).isPresent()) {
+                abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                return;
+            }
+
+            if (!register(discreteSubstore, continuousSubstore, parentId, entry.getValue())) {
+                abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void unregister(List<? extends ResourceId> ids) {
+        // If the transaction was already aborted, skip this operation.
+        if (!transactionContext.isOpen()) {
+            return;
+        }
+
+        checkNotNull(ids);
+
+        // Look up resources by resource IDs
+        List<Resource> resources = ids.stream()
+                .filter(x -> x.parent().isPresent())
+                .map(x -> {
+                    // avoid access to consistent map in the case of discrete resource
+                    if (x instanceof DiscreteResourceId) {
+                        return Optional.of(Resources.discrete((DiscreteResourceId) x).resource());
+                    } else {
+                        return continuousSubstore.lookup((ContinuousResourceId) x);
+                    }
+                })
+                .flatMap(Tools::stream)
+                .collect(Collectors.toList());
+        // the order is preserved by LinkedHashMap
+        Map<DiscreteResourceId, List<Resource>> resourceMap = resources.stream()
+                .collect(Collectors.groupingBy(x -> x.parent().get().id(), LinkedHashMap::new, Collectors.toList()));
+
+        for (Map.Entry<DiscreteResourceId, List<Resource>> entry : resourceMap.entrySet()) {
+            if (!unregister(discreteSubstore, continuousSubstore, entry.getKey(), entry.getValue())) {
+                log.warn("Failed to unregister {}: Failed to remove {} values.",
+                        entry.getKey(), entry.getValue().size());
+                log.debug("Failed to unregister {}: Failed to remove values: {}",
+                        entry.getKey(), entry.getValue());
+                abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void allocate(List<? extends Resource> resources, ResourceConsumer consumer) {
+        // If the transaction was already aborted, skip this operation.
+        if (!transactionContext.isOpen()) {
+            return;
+        }
+
+        checkNotNull(resources);
+        checkNotNull(consumer);
+
+        for (Resource resource : resources) {
+            if (resource instanceof DiscreteResource) {
+                if (!discreteSubstore.allocate(consumer.consumerId(), (DiscreteResource) resource)) {
+                    abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                    return;
+                }
+            } else if (resource instanceof ContinuousResource) {
+                if (!continuousSubstore.allocate(consumer.consumerId(), (ContinuousResource) resource)) {
+                    abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                    return;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void release(List<ResourceAllocation> allocations) {
+        // If the transaction was already aborted, skip this operation.
+        if (!transactionContext.isOpen()) {
+            return;
+        }
+
+        checkNotNull(allocations);
+
+        for (ResourceAllocation allocation : allocations) {
+            Resource resource = allocation.resource();
+            ResourceConsumerId consumerId = allocation.consumerId();
+
+            if (resource instanceof DiscreteResource) {
+                if (!discreteSubstore.release(consumerId, (DiscreteResource) resource)) {
+                    abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                    return;
+                }
+            } else if (resource instanceof ContinuousResource) {
+                if (!continuousSubstore.release(consumerId, (ContinuousResource) resource)) {
+                    abortTransaction(ResourceCommitStatus.FAILED_ALLOCATION);
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Appends the values to the existing values associated with the specified key.
+     * If the map already has all the given values, appending will not happen.
+     *
+     * @param parent    resource ID of the parent under which the given resources are registered
+     * @param resources resources to be registered
+     * @return true if the operation succeeds, false otherwise.
+     */
+    // computational complexity: O(n) where n is the number of the specified value
+    private boolean register(TransactionalDiscreteResourceSubStore discreteTxStore,
+            TransactionalContinuousResourceSubStore continuousTxStore,
+            DiscreteResourceId parent, List<Resource> resources) {
+        // it's assumed that the passed "values" is non-empty
+
+        // This is 2-pass scan. Nicer to have 1-pass scan
+        Set<DiscreteResource> discreteResources = resources.stream()
+                .filter(x -> x instanceof DiscreteResource)
+                .map(x -> (DiscreteResource) x)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<ContinuousResource> continuousResources = resources.stream()
+                .filter(x -> x instanceof ContinuousResource)
+                .map(x -> (ContinuousResource) x)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return discreteTxStore.register(parent, discreteResources)
+                && continuousTxStore.register(parent, continuousResources);
+    }
+
+    /**
+     * Removes the values from the existing values associated with the specified key.
+     * If the map doesn't contain the given values, removal will not happen.
+     *
+     * @param discreteTxStore   map holding multiple discrete resources for a key
+     * @param continuousTxStore map holding multiple continuous resources for a key
+     * @param parent            resource ID of the parent under which the given resources are unregistered
+     * @param resources         resources to be unregistered
+     * @return true if the operation succeeds, false otherwise
+     */
+    private boolean unregister(TransactionalDiscreteResourceSubStore discreteTxStore,
+            TransactionalContinuousResourceSubStore continuousTxStore,
+            DiscreteResourceId parent, List<Resource> resources) {
+        // it's assumed that the passed "values" is non-empty
+
+        // This is 2-pass scan. Nicer to have 1-pass scan
+        Set<DiscreteResource> discreteResources = resources.stream()
+                .filter(x -> x instanceof DiscreteResource)
+                .map(x -> (DiscreteResource) x)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<ContinuousResource> continuousResources = resources.stream()
+                .filter(x -> x instanceof ContinuousResource)
+                .map(x -> (ContinuousResource) x)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return discreteTxStore.unregister(parent, discreteResources)
+                && continuousTxStore.unregister(parent, continuousResources);
+    }
+
+    /**
+     * Aborts the transaction with the given commit status.
+     *
+     * @param status the status with which to abort the transaction
+     */
+    private void abortTransaction(ResourceCommitStatus status) {
+        transactionContext.abort();
+        this.commitStatus = status;
+    }
+
+    @Override
+    public ResourceCommitStatus commit() {
+        // If the transaction is not open, that indicates it was already aborted. Return the set commit status.
+        if (!transactionContext.isOpen()) {
+            return commitStatus;
+        }
+        return transactionContext.commit().join() == CommitStatus.SUCCESS
+                ? ResourceCommitStatus.SUCCEEDED
+                : ResourceCommitStatus.FAILED_CONCURRENT_TRANSACTION;
+    }
+
+    @Override
+    public void abort() {
+        transactionContext.abort();
+    }
+
+    @Override
+    public void close() {
+        if (transactionContext.isOpen()) {
+            transactionContext.abort();
+        }
+    }
+}

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ContinuousResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/ContinuousResourceSubStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-present Open Networking Laboratory
+ * Copyright 2017-present Open Networking Laboratory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onosproject.net.resource;
+package org.onosproject.store.resource.impl;
 
-import com.google.common.annotations.Beta;
-import org.onosproject.store.Store;
+import org.onosproject.net.resource.ContinuousResource;
+import org.onosproject.net.resource.ContinuousResourceId;
 
 /**
- * Service for storing resource and consumer information.
+ * Continuous resource substore.
  */
-@Beta
-public interface ResourceStore extends Store<ResourceEvent, ResourceStoreDelegate>, ResourceStoreBase {
-
-    /**
-     * Creates a new resource transaction context.
-     *
-     * @return a new resource transaction context
-     */
-    ResourceTransactionContext newTransaction();
-
+public interface ContinuousResourceSubStore
+        extends ConsistentResourceSubStore<ContinuousResourceId, ContinuousResource> {
 }

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/DiscreteResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/DiscreteResourceSubStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-present Open Networking Laboratory
+ * Copyright 2017-present Open Networking Laboratory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.onosproject.net.resource;
+package org.onosproject.store.resource.impl;
 
-import com.google.common.annotations.Beta;
-import org.onosproject.store.Store;
+import org.onosproject.net.resource.DiscreteResource;
+import org.onosproject.net.resource.DiscreteResourceId;
 
 /**
- * Service for storing resource and consumer information.
+ * Discrete resource substore.
  */
-@Beta
-public interface ResourceStore extends Store<ResourceEvent, ResourceStoreDelegate>, ResourceStoreBase {
-
-    /**
-     * Creates a new resource transaction context.
-     *
-     * @return a new resource transaction context
-     */
-    ResourceTransactionContext newTransaction();
-
+public interface DiscreteResourceSubStore extends ConsistentResourceSubStore<DiscreteResourceId, DiscreteResource> {
 }

--- a/core/store/dist/src/main/java/org/onosproject/store/resource/impl/TransactionalResourceSubStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/resource/impl/TransactionalResourceSubStore.java
@@ -26,7 +26,8 @@ import java.util.Set;
 /**
  * Interface for transaction resource substores.
  */
-interface TransactionalResourceSubStore<T extends ResourceId, U extends Resource> {
+interface TransactionalResourceSubStore<T extends ResourceId, U extends Resource>
+        extends ConsistentResourceSubStore<T, U> {
 
     /**
      * Reads the given resource from the substore.


### PR DESCRIPTION
This PR refactors the resource subsystem to support transactions. The resource transaction API closely mimics that of the underlying transaction primitive, but exposes methods specific to resource allocation.

```java
// Create and start a new transaction
ResourceTransaction transaction = resourceService.transaction();
transaction.begin();

// Do some resource allocation stuffs
transaction.getResourceAllocations(...);
transaction.allocate(...);
transaction.release(...);

// Attempt to commit the transaction
if (transaction.commit()) {
    log.debug("Transaction succeeded!");
} else {
    log.warn("Transaction failed");
}
```